### PR TITLE
remove redirected posts (with yoast seo) from the algolia index

### DIFF
--- a/classes/class-no-index-manager.php
+++ b/classes/class-no-index-manager.php
@@ -5,7 +5,7 @@ namespace Yoast\YoastCom\AlgoliaModifications;
 class No_Index_Manager {
 
 	public function register_hooks() {
-		add_filter( 'algolia_should_index_searchable_post', array( $this, 'blacklist_no_index_posts'), 10, 2 );
+		add_filter( 'algolia_should_index_searchable_post', array( $this, 'blacklist_no_index_posts' ), 10, 2 );
 	}
 
 	public function blacklist_no_index_posts( $should_index, \WP_Post $post ) {

--- a/classes/class-redirect-manager.php
+++ b/classes/class-redirect-manager.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Yoast\YoastCom\AlgoliaModifications;
+
+class Redirect_Manager {
+
+	public function register_hooks() {
+		add_filter( 'algolia_should_index_searchable_post', array( $this, 'blacklist_redirected_posts' ), 10, 2 );
+	}
+
+	public function blacklist_redirected_posts( $should_index, \WP_Post $post ) {
+		$redirect_manager = new \WPSEO_Redirect_Manager();
+		if ( $redirect_manager->get_redirect( get_permalink( $post ) ) !== false ) {
+			return false;
+		}
+
+		return $should_index;
+	}
+}


### PR DESCRIPTION
Can be tested by reindexing and checking if redirected posts aren't available in the search on your dev site